### PR TITLE
fix: fixed issue with cudnn failing to initialize due to lack of memory

### DIFF
--- a/src/train_unet.py
+++ b/src/train_unet.py
@@ -25,6 +25,10 @@ import imagereader
 import build_lmdb
 import tempfile
 
+gpu_devices = tf.config.experimental.list_physical_devices('GPU')
+for device in gpu_devices:
+    tf.config.experimental.set_memory_growth(device, True)
+
 EARLY_STOPPING_COUNT = 10
 CONVERGENCE_TOLERANCE = 1e-4
 READER_COUNT = 1 # 1 per GPU, both the reader count and batch size will be scaled based on the number of GPUs


### PR DESCRIPTION
Docker container was failing to launch due to lack of memory. The error was:

```
 (0) Unknown:  Failed to get convolution algorithm. This is probably because cuDNN failed to initialize, so try looking to see if a warning log message was printed above.
     [[node unet/conv2d/Conv2D (defined at /opt/executables/unet_model.py:158) ]]
     [[Identity_1/_4]]
```

This link provides the solution:

https://leimao.github.io/blog/TensorFlow-cuDNN-Failure/
