### PR TITLE
Added use_intensity_scaling and augment_intensity flags as input parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ usage: train_unet [-h] --imageDir IMAGE_DIR --maskDir MASK_DIR
                   --tensorboardDir TENSORBOARD_DIR
                   [--testEveryNSteps TEST_EVERY_N_STEPS]
                   [--balanceClasses BALANCE_CLASSES]
+                  [--useIntensityScaling USE_INTENSITY_SCALING] 
                   [--useAugmentation USE_AUGMENTATION]
                   [--augmentationReflection AUGMENTATION_REFLECTION]
                   [--augmentationRotation AUGMENTATION_ROTATION]

--- a/README.md
+++ b/README.md
@@ -51,5 +51,6 @@ usage: train_unet [-h] --imageDir IMAGE_DIR --maskDir MASK_DIR
                   [--augmentationNoise AUGMENTATION_NOISE]
                   [--augmentationScale AUGMENTATION_SCALE]
                   [--augmentationBlurMaxSigma AUGMENTATION_BLUR_MAX_SIGMA]
+                  [--augmentationIntensity AUGMENTATION_INTENSITY]
 
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ docker pull wipp/wipp-unet-cnn-train-plugin
 ```bash
 #!/bin/bash
 
-version=0.0.1
+version=0.0.6
 docker build . -t wipp/wipp-unet-cnn-train-plugin:latest
 docker build . -t wipp/wipp-unet-cnn-train-plugin:${version}
 ```

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -6,6 +6,6 @@
 # You are solely responsible for determining the appropriateness of using and distributing the software and you assume all risks associated with its use, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of operation. This software is not intended to be used in any situation where a failure could cause risk of injury or damage to property. The software developed by NIST employees is not subject to copyright protection within the United States.
 
 
-version=0.0.5
+version=0.0.6
 docker build . -t wipp/wipp-unet-cnn-train-plugin:latest
 docker build . -t wipp/wipp-unet-cnn-train-plugin:${version}

--- a/plugin.json
+++ b/plugin.json
@@ -95,6 +95,18 @@
       "required": true,
       "default": "YES"
     },
+      {
+      "name": "useIntensityScaling",
+      "type": "enum",
+			"options": {
+				"values": [
+					"NO","YES"
+				]
+			},
+      "description": "Controls whether or not to intensity-scale the input images for training in order to accommodate unevenly distributed intensity-defining classes across multiple images.",
+      "required": true,
+      "default": "YES"
+    },
     {
       "name": "useAugmentation",
       "type": "enum",

--- a/plugin.json
+++ b/plugin.json
@@ -1,13 +1,13 @@
 {
   "name": "WIPP UNet CNN Training Plugin",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "title": "UNet CNN Training",
 "author": "Michael Majurski",
 "institution": "National Institute of Standards and Technology",
 "repository": "https://github.com/usnistgov/WIPP-unet-train-plugin",
 "citation": "Ronneberger, Olaf, Philipp Fischer, and Thomas Brox. \"U-net: Convolutional networks for biomedical image segmentation.\" International Conference on Medical image computing and computer-assisted intervention. Springer, Cham, 2015.",
   "description": "Train a UNet CNN model",
-  "containerId": "wipp/wipp-unet-cnn-train-plugin:0.0.4",
+  "containerId": "wipp/wipp-unet-cnn-train-plugin:0.0.6",
   "inputs": [
 
     {

--- a/plugin.json
+++ b/plugin.json
@@ -173,6 +173,13 @@
       "description": "The max size of a gaussian blur kernel used to blur the images [0 = None]. Blur augmentation performs a gaussian smoothing of the image to blur out details. This controls how large the blur kernel is, and therefore the strength of the blurring effect.",
       "required": false,
       "default": 2
+    },
+    {
+      "name": "augmentationIntensity",
+      "type": "number",
+      "description": "The severity of intensity data augmentation [0 = None, 1 = 100% of dynamic range]. Intensity augmentation shifts the intensity values by a percentage of the dynamic range.",
+      "required": false,
+      "default": 0.0
     }
   ],
   "outputs": [

--- a/push-docker.sh
+++ b/push-docker.sh
@@ -6,6 +6,6 @@
 # You are solely responsible for determining the appropriateness of using and distributing the software and you assume all risks associated with its use, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of operation. This software is not intended to be used in any situation where a failure could cause risk of injury or damage to property. The software developed by NIST employees is not subject to copyright protection within the United States.
 
 
-version=0.0.5
+version=0.0.6
 docker push wipp/wipp-unet-cnn-train-plugin:latest
 docker push wipp/wipp-unet-cnn-train-plugin:${version}

--- a/src/build_lmdb.py
+++ b/src/build_lmdb.py
@@ -216,6 +216,8 @@ def build_database(image_folder, mask_folder, output_folder, dataset_name, train
     # find the image files for which annotations exist
     img_files = [f for f in os.listdir(mask_folder) if f.endswith('.{}'.format(image_format))]
 
+    print('len(img_files)', len(img_files))
+
     # in place shuffle
     random.shuffle(img_files)
 
@@ -269,7 +271,11 @@ def main():
     image_format = args.image_format
     tile_size = args.tile_size
 
+    print('test:', image_folder)
+
     build_database(image_folder, mask_folder, output_folder, dataset_name, train_fraction, image_format, tile_size)
 
+if __name__ == "__main__":
+    main()
 
 

--- a/src/imagereader.py
+++ b/src/imagereader.py
@@ -207,11 +207,12 @@ def apply_affine_transformation(I, orientation, reflect_x, reflect_y, jitter_x, 
 
 class ImageReader:
 
-    def __init__(self, img_db, use_augmentation=True, balance_classes=False, shuffle=True, num_workers=1, number_classes=2, augmentation_reflection=0, augmentation_rotation=0, augmentation_jitter=0, augmentation_noise=0, augmentation_scale=0, augmentation_blur_max_sigma=0):
+    def __init__(self, img_db, use_intensity_scaling = False, use_augmentation=True, balance_classes=False, shuffle=True, num_workers=1, number_classes=2, augmentation_reflection=0, augmentation_rotation=0, augmentation_jitter=0, augmentation_noise=0, augmentation_scale=0, augmentation_blur_max_sigma=0):
         random.seed()
 
         # copy inputs to class variables
         self.image_db = img_db
+        self.use_intensity_scaling = use_intensity_scaling # added for the concrete project
         self.use_augmentation = use_augmentation
         self.balance_classes = balance_classes
         self.shuffle = shuffle
@@ -418,7 +419,8 @@ class ImageReader:
                 # reshape into tensor (CHW)
                 I = I.transpose((2, 0, 1))
                 I = I.astype(np.float32)
-                I = zscore_normalize(I)
+                if self.use_intensity_scaling: # added for the concrete project
+                    I = zscore_normalize(I)
 
                 M = M.astype(np.int32)
                 # convert to a one-hot (HWC) representation

--- a/src/imagereader.py
+++ b/src/imagereader.py
@@ -207,7 +207,7 @@ def apply_affine_transformation(I, orientation, reflect_x, reflect_y, jitter_x, 
 
 class ImageReader:
 
-    def __init__(self, img_db, use_intensity_scaling = False, use_augmentation=True, balance_classes=False, shuffle=True, num_workers=1, number_classes=2, augmentation_reflection=0, augmentation_rotation=0, augmentation_jitter=0, augmentation_noise=0, augmentation_scale=0, augmentation_blur_max_sigma=0):
+    def __init__(self, img_db, use_intensity_scaling = False, use_augmentation=True, balance_classes=False, shuffle=True, num_workers=1, number_classes=2, augmentation_reflection=0, augmentation_rotation=0, augmentation_jitter=0, augmentation_noise=0, augmentation_scale=0, augmentation_blur_max_sigma=0, augmentation_intensity=0):
         random.seed()
 
         # copy inputs to class variables
@@ -225,6 +225,7 @@ class ImageReader:
         self._noise_augmentation_severity = augmentation_noise
         self._scale_augmentation_severity = augmentation_scale
         self._blur_max_sigma = augmentation_blur_max_sigma
+        self.intensity_augmentation_severity = augmentation_intensity
 
         # init class state
         self.queue_starvation = False
@@ -413,7 +414,8 @@ class ImageReader:
                                          jitter_augmentation_severity=self._jitter_augmentation_severity,
                                          noise_augmentation_severity=self._noise_augmentation_severity,
                                          scale_augmentation_severity=self._scale_augmentation_severity,
-                                         blur_augmentation_max_sigma=self._blur_max_sigma)
+                                         blur_augmentation_max_sigma=self._blur_max_sigma,
+                                         intensity_augmentation_severity=self.intensity_augmentation_severity)
 
                 # format the image into a tensor
                 # reshape into tensor (CHW)

--- a/src/isg_ai_pb2.py
+++ b/src/isg_ai_pb2.py
@@ -21,6 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto2',
   serialized_pb=_b('\n\x0cisg_ai.proto\x12\x06isg_ai\"\x9a\x01\n\rImageMaskPair\x12\x10\n\x08\x63hannels\x18\x01 \x01(\x05\x12\x12\n\nimg_height\x18\x02 \x01(\x05\x12\x11\n\timg_width\x18\x03 \x01(\x05\x12\x10\n\x08img_type\x18\x04 \x01(\t\x12\x11\n\tmask_type\x18\x05 \x01(\t\x12\r\n\x05image\x18\x06 \x01(\x0c\x12\x0c\n\x04mask\x18\x07 \x01(\x0c\x12\x0e\n\x06labels\x18\x08 \x01(\x0c')
 )
+_sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 
 
@@ -38,56 +39,56 @@ _IMAGEMASKPAIR = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
+      options=None),
     _descriptor.FieldDescriptor(
       name='img_height', full_name='isg_ai.ImageMaskPair.img_height', index=1,
       number=2, type=5, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
+      options=None),
     _descriptor.FieldDescriptor(
       name='img_width', full_name='isg_ai.ImageMaskPair.img_width', index=2,
       number=3, type=5, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
+      options=None),
     _descriptor.FieldDescriptor(
       name='img_type', full_name='isg_ai.ImageMaskPair.img_type', index=3,
       number=4, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
+      options=None),
     _descriptor.FieldDescriptor(
       name='mask_type', full_name='isg_ai.ImageMaskPair.mask_type', index=4,
       number=5, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
+      options=None),
     _descriptor.FieldDescriptor(
       name='image', full_name='isg_ai.ImageMaskPair.image', index=5,
       number=6, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
+      options=None),
     _descriptor.FieldDescriptor(
       name='mask', full_name='isg_ai.ImageMaskPair.mask', index=6,
       number=7, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
+      options=None),
     _descriptor.FieldDescriptor(
       name='labels', full_name='isg_ai.ImageMaskPair.labels', index=7,
       number=8, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
+      options=None),
   ],
   extensions=[
   ],
@@ -105,7 +106,6 @@ _IMAGEMASKPAIR = _descriptor.Descriptor(
 )
 
 DESCRIPTOR.message_types_by_name['ImageMaskPair'] = _IMAGEMASKPAIR
-_sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 ImageMaskPair = _reflection.GeneratedProtocolMessageType('ImageMaskPair', (_message.Message,), dict(
   DESCRIPTOR = _IMAGEMASKPAIR,

--- a/src/train_unet.py
+++ b/src/train_unet.py
@@ -191,7 +191,7 @@ def main():
     parser.add_argument('--trainFraction', dest='train_fraction', type=float, help='what fraction of the dataset to use for training (0.0, 1.0)', default=0.8)
     # added for the concrete project
     parser.add_argument('--useIntensityScaling', dest='use_intensity_scaling', type=str,
-                        help='whether to use intensity scaling when training [YES, NO]', default="NO")
+                        help='whether to use intensity scaling when training [YES, NO]', default="YES")
 
     # Training parameters
     parser.add_argument('--batchSize', dest='batch_size', type=int, help='training batch size', default=4)

--- a/src/train_unet.py
+++ b/src/train_unet.py
@@ -34,7 +34,7 @@ CONVERGENCE_TOLERANCE = 1e-4
 READER_COUNT = 1 # 1 per GPU, both the reader count and batch size will be scaled based on the number of GPUs
 
 # use_intensity_scaling was added for the concrete project 2020-09-15
-def train_model(output_folder, tensorboard_dir, scratch_dir, batch_size, train_lmdb_filepath, test_lmdb_filepath, number_classes, balance_classes, learning_rate, test_every_n_steps, use_intensity_scaling, use_augmentation, augmentation_reflection, augmentation_rotation, augmentation_jitter, augmentation_noise, augmentation_scale, augmentation_blur_max_sigma):
+def train_model(output_folder, tensorboard_dir, scratch_dir, batch_size, train_lmdb_filepath, test_lmdb_filepath, number_classes, balance_classes, learning_rate, test_every_n_steps, use_intensity_scaling, use_augmentation, augmentation_reflection, augmentation_rotation, augmentation_jitter, augmentation_noise, augmentation_scale, augmentation_blur_max_sigma, augmentation_intensity):
     if not os.path.exists(output_folder):
         os.makedirs(output_folder)
 
@@ -54,7 +54,7 @@ def train_model(output_folder, tensorboard_dir, scratch_dir, batch_size, train_l
         print('Test Reader has {} images'.format(test_reader.get_image_count()))
 
         print('Setting up training image reader')
-        train_reader = imagereader.ImageReader(train_lmdb_filepath, use_intensity_scaling=use_intensity_scaling, use_augmentation=use_augmentation, shuffle=True, num_workers=reader_count, balance_classes=balance_classes, number_classes=number_classes, augmentation_reflection=augmentation_reflection, augmentation_rotation=augmentation_rotation, augmentation_jitter=augmentation_jitter, augmentation_noise=augmentation_noise, augmentation_scale=augmentation_scale, augmentation_blur_max_sigma=augmentation_blur_max_sigma)
+        train_reader = imagereader.ImageReader(train_lmdb_filepath, use_intensity_scaling=use_intensity_scaling, use_augmentation=use_augmentation, shuffle=True, num_workers=reader_count, balance_classes=balance_classes, number_classes=number_classes, augmentation_reflection=augmentation_reflection, augmentation_rotation=augmentation_rotation, augmentation_jitter=augmentation_jitter, augmentation_noise=augmentation_noise, augmentation_scale=augmentation_scale, augmentation_blur_max_sigma=augmentation_blur_max_sigma, augmentation_intensity=augmentation_intensity)
         print('Train Reader has {} images'.format(train_reader.get_image_count()))
 
         try:  # if any errors happen we want to catch them and shut down the multiprocess readers
@@ -205,12 +205,13 @@ def main():
     # Augmentation parameters
     parser.add_argument('--useAugmentation', dest='use_augmentation', type=str, help='whether to use data augmentation [YES, NO]', default="NO")
     parser.add_argument('--augmentationReflection', dest='augmentation_reflection', type=str, help='whether to use reflection data augmentation [YES, NO]', default="YES")
-    parser.add_argument('--augmentationRotation', dest='augmentation_rotation', type=str, help='whether to use roation data augmentation [YES, NO]', default="YES")
+    parser.add_argument('--augmentationRotation', dest='augmentation_rotation', type=str, help='whether to use rotation data augmentation [YES, NO]', default="YES")
     parser.add_argument('--augmentationJitter', dest='augmentation_jitter', type=float, help='jitter data augmentation severity [0 = none, 1 = 100% image size], default = 0.1 (10% image size)', default=0.1)
     parser.add_argument('--augmentationNoise', dest='augmentation_noise', type=float, help='noise data augmentation severity as a percentage of the image dynamic range [0 = none, 1 = 100%], default = 0.02 (2% dynamic range)', default=0.02)
     parser.add_argument('--augmentationScale', dest='augmentation_scale', type=float, help='scale data augmentation severity as a percentage of the image size [0 = none, 1 = 100%], default = 0.1 (10% max change in image size)', default=0.1)
     parser.add_argument('--augmentationBlurMaxSigma', dest='augmentation_blur_max_sigma', type=float, help='maximum sigma to use in a gaussian blurring kernel. Blur kernel is selected as rand(0, max)', default=2)
-
+    # added for the concrete project
+    parser.add_argument('--augmentationIntensity', dest='augmentation_intensity', type=float, help='intensity data augmentation severity [0 = none, 1 = 100% dynamic range], default = 0 (0% image size)', default=0.0)
 
     print('****************************************')
     # verify the GPU is visible as it is required
@@ -271,6 +272,8 @@ def main():
         augmentation_noise = args.augmentation_noise
         augmentation_scale = args.augmentation_scale
         augmentation_blur_max_sigma = args.augmentation_blur_max_sigma
+        augmentation_intensity = args.augmentation_intensity
+
 
         print('augmentation_reflection = {}'.format(augmentation_reflection))
         print('augmentation_rotation = {}'.format(augmentation_rotation))
@@ -278,6 +281,7 @@ def main():
         print('augmentation_noise = {}'.format(augmentation_noise))
         print('augmentation_scale = {}'.format(augmentation_scale))
         print('augmentation_blur_max_sigma = {}'.format(augmentation_blur_max_sigma))
+        print('augmentation_intensity = {}'.format(augmentation_intensity))
 
     else:
         augmentation_reflection = 0
@@ -286,6 +290,7 @@ def main():
         augmentation_noise = 0
         augmentation_scale= 0
         augmentation_blur_max_sigma = 0
+        augmentation_intensity = 0
 
     dataset_name = 'unet'
     image_format = 'tif'
@@ -298,7 +303,7 @@ def main():
         train_lmdb_filepath = os.path.join(scratch_dir, train_database_name)
         test_lmdb_filepath = os.path.join(scratch_dir, test_database_name)
 
-        train_model(output_dir, tensorboard_dir, scratch_dir, batch_size, train_lmdb_filepath, test_lmdb_filepath, number_classes, balance_classes, learning_rate, test_every_n_steps, use_intensity_scaling, use_augmentation, augmentation_reflection, augmentation_rotation, augmentation_jitter, augmentation_noise, augmentation_scale, augmentation_blur_max_sigma)
+        train_model(output_dir, tensorboard_dir, scratch_dir, batch_size, train_lmdb_filepath, test_lmdb_filepath, number_classes, balance_classes, learning_rate, test_every_n_steps, use_intensity_scaling, use_augmentation, augmentation_reflection, augmentation_rotation, augmentation_jitter, augmentation_noise, augmentation_scale, augmentation_blur_max_sigma, augmentation_intensity)
 
 
 

--- a/src/train_unet.py
+++ b/src/train_unet.py
@@ -33,8 +33,8 @@ EARLY_STOPPING_COUNT = 10
 CONVERGENCE_TOLERANCE = 1e-4
 READER_COUNT = 1 # 1 per GPU, both the reader count and batch size will be scaled based on the number of GPUs
 
-
-def train_model(output_folder, tensorboard_dir, scratch_dir, batch_size, train_lmdb_filepath, test_lmdb_filepath, number_classes, balance_classes, learning_rate, test_every_n_steps, use_augmentation, augmentation_reflection, augmentation_rotation, augmentation_jitter, augmentation_noise, augmentation_scale, augmentation_blur_max_sigma):
+# use_intensity_scaling was added for the concrete project 2020-09-15
+def train_model(output_folder, tensorboard_dir, scratch_dir, batch_size, train_lmdb_filepath, test_lmdb_filepath, number_classes, balance_classes, learning_rate, test_every_n_steps, use_intensity_scaling, use_augmentation, augmentation_reflection, augmentation_rotation, augmentation_jitter, augmentation_noise, augmentation_scale, augmentation_blur_max_sigma):
     if not os.path.exists(output_folder):
         os.makedirs(output_folder)
 
@@ -48,12 +48,13 @@ def train_model(output_folder, tensorboard_dir, scratch_dir, batch_size, train_l
         # scale the number of I/O readers based on the GPU count
         reader_count = READER_COUNT * mirrored_strategy.num_replicas_in_sync
 
+        # the flag use_intensity_scale was added for the concrete project
         print('Setting up test image reader')
-        test_reader = imagereader.ImageReader(test_lmdb_filepath, use_augmentation=False, shuffle=False, num_workers=reader_count, balance_classes=False, number_classes=number_classes)
+        test_reader = imagereader.ImageReader(test_lmdb_filepath, use_intensity_scaling=use_intensity_scaling, use_augmentation=False, shuffle=False, num_workers=reader_count, balance_classes=False, number_classes=number_classes)
         print('Test Reader has {} images'.format(test_reader.get_image_count()))
 
         print('Setting up training image reader')
-        train_reader = imagereader.ImageReader(train_lmdb_filepath, use_augmentation=use_augmentation, shuffle=True, num_workers=reader_count, balance_classes=balance_classes, number_classes=number_classes, augmentation_reflection=augmentation_reflection, augmentation_rotation=augmentation_rotation, augmentation_jitter=augmentation_jitter, augmentation_noise=augmentation_noise, augmentation_scale=augmentation_scale, augmentation_blur_max_sigma=augmentation_blur_max_sigma)
+        train_reader = imagereader.ImageReader(train_lmdb_filepath, use_intensity_scaling=use_intensity_scaling, use_augmentation=use_augmentation, shuffle=True, num_workers=reader_count, balance_classes=balance_classes, number_classes=number_classes, augmentation_reflection=augmentation_reflection, augmentation_rotation=augmentation_rotation, augmentation_jitter=augmentation_jitter, augmentation_noise=augmentation_noise, augmentation_scale=augmentation_scale, augmentation_blur_max_sigma=augmentation_blur_max_sigma)
         print('Train Reader has {} images'.format(train_reader.get_image_count()))
 
         try:  # if any errors happen we want to catch them and shut down the multiprocess readers
@@ -188,6 +189,9 @@ def main():
     parser.add_argument('--useTiling', dest='use_tiling', type=str, help='whether to use tiling when training [YES, NO]', default="NO")
     parser.add_argument('--tileSize', dest='tile_size', type=int, default=256)
     parser.add_argument('--trainFraction', dest='train_fraction', type=float, help='what fraction of the dataset to use for training (0.0, 1.0)', default=0.8)
+    # added for the concrete project
+    parser.add_argument('--useIntensityScaling', dest='use_intensity_scaling', type=str,
+                        help='whether to use intensity scaling when training [YES, NO]', default="NO")
 
     # Training parameters
     parser.add_argument('--batchSize', dest='batch_size', type=int, help='training batch size', default=4)
@@ -219,17 +223,21 @@ def main():
     # lmdb parameters
     use_tiling = args.use_tiling
     use_tiling = use_tiling.upper() == "YES"
+    use_intensity_scaling = args.use_intensity_scaling
+    use_intensity_scaling = use_intensity_scaling.upper() == "YES"
 
     tile_size = args.tile_size
     image_dir = args.image_dir
     mask_dir = args.mask_dir
     train_fraction = args.train_fraction
 
+
     print('use_tiling = {}'.format(use_tiling))
     print('tile_size = {}'.format(tile_size))
     print('image_dir = {}'.format(image_dir))
     print('mask_dir = {}'.format(mask_dir))
     print('train_fraction = []'.format(train_fraction))
+    print('use_intensity_scaling = {}'.format(use_intensity_scaling))
 
     # Training parameters
     batch_size = args.batch_size
@@ -290,7 +298,7 @@ def main():
         train_lmdb_filepath = os.path.join(scratch_dir, train_database_name)
         test_lmdb_filepath = os.path.join(scratch_dir, test_database_name)
 
-        train_model(output_dir, tensorboard_dir, scratch_dir, batch_size, train_lmdb_filepath, test_lmdb_filepath, number_classes, balance_classes, learning_rate, test_every_n_steps, use_augmentation, augmentation_reflection, augmentation_rotation, augmentation_jitter, augmentation_noise, augmentation_scale, augmentation_blur_max_sigma)
+        train_model(output_dir, tensorboard_dir, scratch_dir, batch_size, train_lmdb_filepath, test_lmdb_filepath, number_classes, balance_classes, learning_rate, test_every_n_steps, use_intensity_scaling, use_augmentation, augmentation_reflection, augmentation_rotation, augmentation_jitter, augmentation_noise, augmentation_scale, augmentation_blur_max_sigma)
 
 
 


### PR DESCRIPTION
This change is motivated by the fact that pixel-level intensity might be critical for pixel classification and is lost by z-normalization. This is the case for training images where each image contains only a small fraction of the targeted pixel-level class labels.