### PR TITLE
singularity compatibility, bump version to 0.0.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,6 @@ RUN pip3 install lmdb scikit-image imagecodecs
 #Copy executable
 COPY src ${EXEC_DIR}/
 
-WORKDIR ${EXEC_DIR}
-
 # Default command. Additional arguments are provided through the command line
-ENTRYPOINT ["python3", "train_unet.py"]
+ENTRYPOINT ["python3", "/opt/executables/train_unet.py"]
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ docker pull wipp/wipp-unet-cnn-train-plugin
 ```bash
 #!/bin/bash
 
-version=0.0.6
+version=0.0.8
 docker build . -t wipp/wipp-unet-cnn-train-plugin:latest
 docker build . -t wipp/wipp-unet-cnn-train-plugin:${version}
 ```

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -6,6 +6,6 @@
 # You are solely responsible for determining the appropriateness of using and distributing the software and you assume all risks associated with its use, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of operation. This software is not intended to be used in any situation where a failure could cause risk of injury or damage to property. The software developed by NIST employees is not subject to copyright protection within the United States.
 
 
-version=0.0.6
+version=0.0.8
 docker build . -t wipp/wipp-unet-cnn-train-plugin:latest
 docker build . -t wipp/wipp-unet-cnn-train-plugin:${version}

--- a/plugin.json
+++ b/plugin.json
@@ -1,13 +1,13 @@
 {
   "name": "WIPP UNet CNN Training Plugin",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "title": "UNet CNN Training",
 "author": "Michael Majurski",
 "institution": "National Institute of Standards and Technology",
 "repository": "https://github.com/usnistgov/WIPP-unet-train-plugin",
 "citation": "Ronneberger, Olaf, Philipp Fischer, and Thomas Brox. \"U-net: Convolutional networks for biomedical image segmentation.\" International Conference on Medical image computing and computer-assisted intervention. Springer, Cham, 2015.",
   "description": "Train a UNet CNN model",
-  "containerId": "wipp/wipp-unet-cnn-train-plugin:0.0.7",
+  "containerId": "wipp/wipp-unet-cnn-train-plugin:0.0.8",
   "inputs": [
 
     {

--- a/push-docker.sh
+++ b/push-docker.sh
@@ -6,6 +6,6 @@
 # You are solely responsible for determining the appropriateness of using and distributing the software and you assume all risks associated with its use, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of operation. This software is not intended to be used in any situation where a failure could cause risk of injury or damage to property. The software developed by NIST employees is not subject to copyright protection within the United States.
 
 
-version=0.0.6
+version=0.0.8
 docker push wipp/wipp-unet-cnn-train-plugin:latest
 docker push wipp/wipp-unet-cnn-train-plugin:${version}


### PR DESCRIPTION
Changes:

- remove `WORKDIR` instruction and use absolute path in entrypoint command in Dockerfile for Singularity compatibility
- bump version to 0.0.8